### PR TITLE
Fix form validation feedback typo

### DIFF
--- a/Cutup/js/components/Form.jsx
+++ b/Cutup/js/components/Form.jsx
@@ -70,7 +70,7 @@ export default React.createClass({
 		const validation = validateEmail(email);
 		if (!validation.result) { 
 			this.setState({ 
-				emailError : "Sorry, looks like you've entered an inccorectly formated email... do you mind fixing it up?" 
+				emailError : "Sorry, looks like you've entered an incorrectly formated email... do you mind fixing it up?" 
 			});
 		} else {
 			this.setState({ emailError: false });


### PR DESCRIPTION
This PR fixes a small typo in the inline email validation feedback:

![image](https://cloud.githubusercontent.com/assets/677025/19877326/44195542-a019-11e6-8493-6923fd048a03.png)
